### PR TITLE
Teams Initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /yarn-error.log
 
 .byebug_history
+coverage

--- a/app/controllers/comedians_controller.rb
+++ b/app/controllers/comedians_controller.rb
@@ -1,2 +1,0 @@
-class ComediansController < ApplicationController
-end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,3 @@
+class TeamsController < ApplicationController
+
+end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,3 +1,5 @@
 class TeamsController < ApplicationController
-
+  def index
+    @teams = Team.all
+  end
 end

--- a/app/models/comedian.rb
+++ b/app/models/comedian.rb
@@ -1,2 +1,0 @@
-class Comedian < ApplicationRecord
-end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,2 @@
+class Team < ApplicationRecord
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,2 +1,3 @@
 class Team < ApplicationRecord
+  validates_presence_of :name
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,3 @@
 class Team < ApplicationRecord
-  validates_presence_of :name
+  validates_presence_of :name, :age, :location
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,0 +1,7 @@
+<h1>All Teams</h1>
+
+<% @teams.each do |team| %>
+  <h2><%= team.name %></h2>
+  <p>Age: <%= team.age %></p>
+  <p>Location: <%= team.location %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/teams', to: 'teams#index'
 end

--- a/db/migrate/20190430225345_create_teams.rb
+++ b/db/migrate/20190430225345_create_teams.rb
@@ -1,0 +1,11 @@
+class CreateTeams < ActiveRecord::Migration[5.1]
+  def change
+    create_table :teams do |t|
+      t.string :name
+      t.integer :age
+      t.string :location
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20190430225345) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name"
+    t.integer "age"
+    t.string "location"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'teams index page', type: :feature do
+  it 'user can see all teams' do
+    team_1 = Team.create(name: "Secret", age: 4, location: "Europe")
+    team_2 = Team.create(name: "Natus Vincere", age: 8, location: "Ukraine")
+
+    visit "/teams"
+
+    expect(page).to have_content(team_1.name)
+    expect(page).to have_content("Age: #{team_1.age}")
+    expect(page).to have_content("Location: #{team_1.location}")
+    expect(page).to have_content(team_2.name)
+    expect(page).to have_content("Age: #{team_2.age}")
+    expect(page).to have_content("Location: #{team_2.location}")
+  end
+end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   subject { described_class.new }
+
   it 'is valid with valid attributes' do
     subject.name = "DotA"
     subject.age = 1
@@ -12,7 +13,15 @@ RSpec.describe Team, type: :model do
   it 'is not valid without a name' do
     expect(subject).to_not be_valid
   end
-  
-  it 'is not valid without an age'
-  it 'is not valid without a location'
+
+  it 'is not valid without an age' do
+    subject.name = "DotA"
+    expect(subject).to_not be_valid
+  end
+
+  it 'is not valid without a location' do
+    subject.name = "DotA"
+    subject.age = 1
+    expect(subject).to_not be_valid
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -1,14 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
+  subject { described_class.new }
   it 'is valid with valid attributes' do
-    expect(Team.new(name: 'DotA')).to be_valid
+    subject.name = "DotA"
+    subject.age = 1
+    subject.location = "USA"
+    expect(subject).to be_valid
   end
 
   it 'is not valid without a name' do
-    team = Team.new(name: nil)
-    expect(team).to_not be_valid
+    expect(subject).to_not be_valid
   end
+  
   it 'is not valid without an age'
   it 'is not valid without a location'
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   it 'is valid with valid attributes' do
-    expect(Team.new).to be_valid
+    expect(Team.new(name: 'DotA')).to be_valid
   end
 
   it 'is not valid without a name' do

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Team, type: :model do
+  it 'is valid with valid attributes' do
+    expect(Team.new).to be_valid
+  end
+
+  it 'is not valid without a name' do
+    team = Team.new(name: nil)
+    expect(team).to_not be_valid
+  end
+  it 'is not valid without an age'
+  it 'is not valid without a location'
+end


### PR DESCRIPTION
This PR brings in the functionality of a Team in our application. The first commit was cleaning up, adding our SimpleCov coverage folder to .gitignore. After that however, we began working on the Team Index page test, creating the Teams table in our DB, creating the Team model (replacing the Comedian model) and setting up our Route for the /teams URL.
We then began work on the Teams Controller (again replacing Comedians), which is quite simple. Since the initial iteration of the index page is just listing all of the Teams in our DB, all that our #index method does is set an ivar with all the resources.
Our index takes this information, iterates over it and creates that many elements containing the basic Team information.
Next up was the Teams model test, which could have been done first, but either way, worked. The Team model is simple at this time as well, only validating for Name, Age, and Location.