### PR TITLE
Teams index update and Teams model refactor

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>LaughTracks</title>
+    <title>DotA 2 Tracks</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,7 +1,9 @@
 <h1>All Teams</h1>
 
 <% @teams.each do |team| %>
-  <h2><%= team.name %></h2>
-  <p>Age: <%= team.age %></p>
-  <p>Location: <%= team.location %></p>
+  <section class="team" id="team_<%= team.id %>">
+    <h2><%= team.name %></h2>
+    <p>Age: <%= team.age %></p>
+    <p>Location: <%= team.location %></p>
+  </section>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Team.create(name: "Secret", age: 4, location: "Europe")
+Team.create(name: "Natus Vincere", age: 8, location: "Ukraine")

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -7,11 +7,15 @@ RSpec.describe 'teams index page', type: :feature do
 
     visit "/teams"
 
-    expect(page).to have_content(team_1.name)
-    expect(page).to have_content("Age: #{team_1.age}")
-    expect(page).to have_content("Location: #{team_1.location}")
-    expect(page).to have_content(team_2.name)
-    expect(page).to have_content("Age: #{team_2.age}")
-    expect(page).to have_content("Location: #{team_2.location}")
+    within "#team_#{team_1.id}" do
+      expect(page).to have_content(team_1.name)
+      expect(page).to have_content("Age: #{team_1.age}")
+      expect(page).to have_content("Location: #{team_1.location}")
+    end
+    within "#team_#{team_2.id}" do
+      expect(page).to have_content(team_2.name)
+      expect(page).to have_content("Age: #{team_2.age}")
+      expect(page).to have_content("Location: #{team_2.location}")
+    end
   end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -1,27 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  subject { described_class.new }
+  subject { described_class.new(name: "DotA", age: 1, location: "USA") }
 
   it 'is valid with valid attributes' do
-    subject.name = "DotA"
-    subject.age = 1
-    subject.location = "USA"
     expect(subject).to be_valid
   end
 
   it 'is not valid without a name' do
+    subject.name = nil
     expect(subject).to_not be_valid
   end
 
   it 'is not valid without an age' do
-    subject.name = "DotA"
+    subject.age = nil
     expect(subject).to_not be_valid
   end
 
   it 'is not valid without a location' do
-    subject.name = "DotA"
-    subject.age = 1
+    subject.location = nil
     expect(subject).to_not be_valid
   end
 end


### PR DESCRIPTION
This PR is mainly about the Teams Index page updating to have each time inside of an section with a "team" CSS class and a "team_id" CSS id.
The first commit is just a simple refactor of the Teams model to use Subject syntax and setting values to nil instead.
Next up, creating seed data for our DB so we can prove the website works, and then improving our View. We needed our test to make sure that each team contained the correct information, which required looking within a section. Our View now iterates through the Teams, pulls their ID, and THEN puts all the relevant info into that Section.