### PR TITLE
Team by Age

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,5 +1,9 @@
 class TeamsController < ApplicationController
   def index
-    @teams = Team.all
+    if params.include?(:age)
+      @teams = Team.by_age(params[:age])
+    else
+      @teams = Team.all
+    end
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,9 @@
 class Team < ApplicationRecord
   has_many :players
-  
+
   validates_presence_of :name, :age, :location
+
+  def self.by_age(age)
+    where(age: age).all
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,5 +1,11 @@
 <h1>All Teams</h1>
 
+<%= form_tag("/teams", method: "get", enforce_utf8: false) do %>
+  <%= label_tag(:age, "Teams by Age:") %>
+  <%= text_field_tag(:age) %>
+  <%= submit_tag("Search", name: nil) %>
+<% end %>
+
 <% @teams.each do |team| %>
   <section class="team" id="team_<%= team.id %>">
     <h2><%= team.name %></h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
 Rails.application.routes.draw do
   get '/teams', to: 'teams#index'
-  get '/teams?:age', to: 'teams#by_age'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get '/teams', to: 'teams#index'
+  get '/teams?:age', to: 'teams#by_age'
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -75,7 +75,10 @@ RSpec.describe 'teams index page', type: :feature do
   end
 
   it 'only displays teams with the queried age' do
-    visit "/teams?age=#{@team_1.age}"
+    # visit "/teams?age=#{@team_1.age}
+
+    fill_in "age", with: "#{@team_1.age}"
+    click_button "Search"
 
     expect(page).to have_content(@team_1.name)
     expect(page).to have_content("Age: #{@team_1.age}")

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -73,4 +73,16 @@ RSpec.describe 'teams index page', type: :feature do
       expect(page).to have_css("img[alt='#{player.name} Photo']")
     end
   end
+
+  it 'only displays teams with the queried age' do
+    visit "/teams?age=#{@team_1.age}"
+
+    expect(page).to have_content(@team_1.name)
+    expect(page).to have_content("Age: #{@team_1.age}")
+    expect(page).to have_content("Location: #{@team_1.location}")
+
+    expect(page).to_not have_content(@team_2.name)
+    expect(page).to_not have_content("Age: #{@team_2.age}")
+    expect(page).to_not have_content("Location: #{@team_2.location}")
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -10,4 +10,15 @@ RSpec.describe Team, type: :model do
   describe "associations" do
     it {should have_many :players}
   end
+
+  describe "class methods" do
+    before :each do
+      @team_1 = Team.create(name: "Secret", age: 4, location: "Europe", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/1838315.png")
+      @team_2 = Team.create(name: "Natus Vincere", age: 8, location: "Ukraine", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/36.png")
+    end
+
+    it "should only return teams by age" do
+      expect(Team.by_age(4)).to eq(@team_1)
+    end
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Team, type: :model do
     end
 
     it "should only return teams by age" do
-      expect(Team.by_age(4)).to eq(@team_1)
+      expect(Team.by_age(4)).to eq([@team_1])
     end
   end
 end


### PR DESCRIPTION
This PR brings in a sort functionality to our main /teams page. It allows the user to sort Teams by age, which will then exclude all other teams that do not follow that request. This does not render a new page, it stays on the index and renders a new version with only the correct teams, and the other teams not present at all.
This is done by an if loop in our TeamsController that if `:age` exists in our params, it will make the Teams ivar only the teams that are of that age.
We also added a form to allow the user to search for Teams by Age through there, instead of by modifying the URL.