### PR TITLE
Teams Player Count

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,4 +6,8 @@ class Team < ApplicationRecord
   def self.by_age(age)
     where(age: age).all
   end
+
+  def player_count
+    players.count
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -12,6 +12,7 @@
     <img src="<%= team.image %>" alt="<%= team.name %> Logo">
     <p>Age: <%= team.age %></p>
     <p>Location: <%= team.location %></p>
+    <p>Player Count: <%= team.player_count %></p>
     <% team.players.each do |player| %>
     <aside class="player" id="player_<%= player.id %>">
       <img src="<%= player.image %>" alt="<%= player.name %> Photo">

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -90,14 +90,16 @@ RSpec.describe 'teams index page', type: :feature do
   end
 
   it 'displays the count of players on each team' do
-    team = Team.create(name: "Placeholder", age: 1, location: "Placeholder")
-    player = team.players.create(name: "Placeholder", winrate: 0.5)
+    player1 = @team_1.players.create(name: "Placeholder 1", winrate: 0.5)
+    player2 = @team_1.players.create(name: "Placeholder 2", winrate: 0.5)
 
+    visit "/teams"
+    
     within "#team_#{@team_1.id}" do
-      expect(page).to have_content("Player Count: 5")
+      expect(page).to have_content("Player Count: #{@team_1.player_count}")
     end
-    within "#team_#{team.id}" do
-      expect(page).to have_content("Player Count: 1")
+    within "#team_#{@team_2.id}" do
+      expect(page).to have_content("Player Count: #{@team_2.player_count}")
     end
   end
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -88,4 +88,16 @@ RSpec.describe 'teams index page', type: :feature do
     expect(page).to_not have_content("Age: #{@team_2.age}")
     expect(page).to_not have_content("Location: #{@team_2.location}")
   end
+
+  it 'displays the count of players on each team' do
+    team = Team.create(name: "Placeholder", age: 1, location: "Placeholder")
+    player = team.players.create(name: "Placeholder", winrate: 0.5)
+
+    within "#team_#{@team_1.id}" do
+      expect(page).to have_content("Player Count: 5")
+    end
+    within "#team_#{team.id}" do
+      expect(page).to have_content("Player Count: 1")
+    end
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -29,10 +29,16 @@ RSpec.describe Team, type: :model do
     end
 
     it 'should return the count of players on each team' do
+      @team_1.players.create!(name: "Puppey", winrate: 0.666, image: "https://www.opendota.com/assets/images/dota2/players/87278757.png")
+      @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
+      @team_1.players.create!(name: "YapzOr", winrate: 0.676, image: "https://www.opendota.com/assets/images/dota2/players/89117038.png")
+      @team_1.players.create!(name: "zai", winrate: 0.751, image: "https://www.opendota.com/assets/images/dota2/players/73562326.png")
+      @team_1.players.create!(name: "Nisha", winrate: 0.758, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/6d/6d7afedeb7362ba8a2ed0b0ca6cabb63b15fab80_full.jpg")
       team = Team.create(name: "Placeholder", age: 1, location: "Placeholder")
       player = team.players.create(name: "Placeholder", winrate: 0.5)
 
       expect(@team_1.player_count).to eq(5)
+      expect(@team_2.player_count).to eq(0)
       expect(team.player_count).to eq(1)
     end
   end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -21,4 +21,19 @@ RSpec.describe Team, type: :model do
       expect(Team.by_age(4)).to eq([@team_1])
     end
   end
+
+  describe "instance methods" do
+    before :each do
+      @team_1 = Team.create(name: "Secret", age: 4, location: "Europe", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/1838315.png")
+      @team_2 = Team.create(name: "Natus Vincere", age: 8, location: "Ukraine", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/36.png")
+    end
+
+    it 'should return the count of players on each team' do
+      team = Team.create(name: "Placeholder", age: 1, location: "Placeholder")
+      player = team.players.create(name: "Placeholder", winrate: 0.5)
+
+      expect(@team_1.player_count).to eq(5)
+      expect(team.player_count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
This PR brings in the functionality of a Player Count for each Team that we are displaying in our index. This required added a new `p` with the information, but also creating a new instance method for our Team.
It's a simple method, just calling .count on the Players of a Team, but it allows us to avoid calling data directly from the /teams view.