### PR TITLE
New Teams

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -6,4 +6,7 @@ class TeamsController < ApplicationController
       @teams = Team.all
     end
   end
+
+  def new
+  end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -8,6 +8,7 @@ class TeamsController < ApplicationController
   end
 
   def new
+    @new_team = Team.new
   end
 
   def create

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -9,4 +9,15 @@ class TeamsController < ApplicationController
 
   def new
   end
+
+  def create
+    Team.create(team_params)
+    redirect_to "/teams"
+  end
+
+  private
+
+  def team_params
+    params.require(:team).permit(:name, :age, :location)
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,5 +1,7 @@
 <h1>All Teams</h1>
 
+<a href="/teams/new" id="new_team_link">New Team</a>
+
 <%= form_tag("/teams", method: "get", enforce_utf8: false) do %>
   <%= label_tag(:age, "Teams by Age:") %>
   <%= text_field_tag(:age) %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,0 +1,12 @@
+<h2>New Team</h2>
+
+<%= form_for Team.new do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :age %>
+  <%= f.label :age %>
+  <%= f.text_field :location %>
+  <%= f.text_field :location %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -4,8 +4,8 @@
   <%= f.label :name %>
   <%= f.text_field :name %>
   <%= f.label :age %>
-  <%= f.label :age %>
-  <%= f.text_field :location %>
+  <%= f.text_field :age %>
+  <%= f.label :location %>
   <%= f.text_field :location %>
 
   <%= f.submit %>

--- a/app/views/teams/new.html.erb
+++ b/app/views/teams/new.html.erb
@@ -1,6 +1,6 @@
 <h2>New Team</h2>
 
-<%= form_for Team.new do |f| %>
+<%= form_for @new_team do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
   <%= f.label :age %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get '/teams', to: 'teams#index'
+  get '/new', to: 'teams#new'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   get '/teams', to: 'teams#index'
-  get '/new', to: 'teams#new'
+  get 'teams/new', to: 'teams#new'
+  post '/teams', to: 'teams#create'
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -94,12 +94,18 @@ RSpec.describe 'teams index page', type: :feature do
     player2 = @team_1.players.create(name: "Placeholder 2", winrate: 0.5)
 
     visit "/teams"
-    
+
     within "#team_#{@team_1.id}" do
       expect(page).to have_content("Player Count: #{@team_1.player_count}")
     end
     within "#team_#{@team_2.id}" do
       expect(page).to have_content("Player Count: #{@team_2.player_count}")
     end
+  end
+
+  it 'has a link to create a new team' do
+    click_link "New Team"
+
+    expect(current_path).to eq("/teams/new")
   end
 end

--- a/spec/features/teams/new_spec.rb
+++ b/spec/features/teams/new_spec.rb
@@ -6,16 +6,15 @@ RSpec.describe 'New Team', type: :feature do
       it "can create a new Team" do
         visit "/teams/new"
 
-        fill_in "name", with: "Test"
-        fill_in "age", with: 1
-        fill_in "location", with: "Test"
-        click_button "Submit"
+        fill_in "Name", with: "Test"
+        fill_in "Age", with: 1
+        fill_in "Location", with: "Test"
+        click_button "Create Team"
 
         new_team = Team.last
 
         expect(current_path).to eq("/teams")
-
-        within("team_#{new_team.id}") do
+        within("#team_#{new_team.id}") do
           expect(page).to have_content(new_team.name)
           expect(page).to have_content("Age: #{new_team.age}")
           expect(page).to have_content("Location: #{new_team.location}")

--- a/spec/features/teams/new_spec.rb
+++ b/spec/features/teams/new_spec.rb
@@ -4,16 +4,22 @@ RSpec.describe 'New Team', type: :feature do
   describe "As a user" do
     describe "When I visit the new Teams form" do
       it "can create a new Team" do
-          visit "/teams/new"
+        visit "/teams/new"
 
-          fill_in "name", with: "Test"
-          fill_in "age", with: 1
-          fill_in "location", with: "Test"
-          click_button "Submit"
+        fill_in "name", with: "Test"
+        fill_in "age", with: 1
+        fill_in "location", with: "Test"
+        click_button "Submit"
 
-          new_team = Team.last
+        new_team = Team.last
 
-          expect(current_path).to eq("/teams/#{new_team.id}")
+        expect(current_path).to eq("/teams")
+
+        within("team_#{new_team.id}") do
+          expect(page).to have_content(new_team.name)
+          expect(page).to have_content("Age: #{new_team.age}")
+          expect(page).to have_content("Location: #{new_team.location}")
+        end
       end
     end
   end

--- a/spec/features/teams/new_spec.rb
+++ b/spec/features/teams/new_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'New Team', type: :feature do
+  describe "As a user" do
+    describe "When I visit the new Teams form" do
+      it "can create a new Team" do
+          visit "/teams/new"
+
+          fill_in "name", with: "Test"
+          fill_in "age", with: 1
+          fill_in "location", with: "Test"
+          click_button "Submit"
+
+          new_team = Team.last
+
+          expect(current_path).to eq("/teams/#{new_team.id}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality of creating a new Team from inside the web app. The user can be directed to a /teams/new page, where they have a form they can fill out with a Name, Age, and Location. In the future, it would be worth adding an Image form as well.
This follows Rails' Strong Params requirements, keeping the team_params as a private method, before sending to the Team.create method.
It redirects to the main /teams page, and can confirm that the new team has been added.