### PR TITLE
Team Stats

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,6 +2,8 @@ class TeamsController < ApplicationController
   def index
     if params.include?(:age)
       @teams = Team.by_age(params[:age])
+      @average_age = @teams.average_age
+      @team_locations = @teams.locations
     else
       @teams = Team.all
       @average_age = Team.average_age

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,6 +4,8 @@ class TeamsController < ApplicationController
       @teams = Team.by_age(params[:age])
     else
       @teams = Team.all
+      @average_age = Team.average_age
+      @team_locations = Team.locations
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,4 +10,12 @@ class Team < ApplicationRecord
   def player_count
     players.count
   end
+
+  def self.average_age
+    average(:age)
+  end
+
+  def self.locations
+    select(:location).distinct.pluck(:location)
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -11,7 +11,7 @@
 <section id="team_stats">
   <h2>Statistics:</h2>
   <p>Average Age: <%= @average_age %></p>
-  <p>All Team Locations: <%= @team_locations %></p>
+  <p>All Team Locations: <%= @team_locations.join(', ') %></p>
 </section>
 
 <% @teams.each do |team| %>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -7,12 +7,15 @@
   <%= text_field_tag(:age) %>
   <%= submit_tag("Search", name: nil) %>
 <% end %>
-
-<section id="team_stats">
-  <h2>Statistics:</h2>
-  <p>Average Age: <%= @average_age %></p>
-  <p>All Team Locations: <%= @team_locations.join(', ') %></p>
-</section>
+<% if @teams.empty? %>
+  <p>Sorry, nothing for you here!</p>
+<% else %>
+  <section id="team_stats">
+    <h2>Statistics:</h2>
+    <p>Average Age: <%= @average_age.round(2) %></p>
+    <p>All Team Locations: <%= @team_locations.join(', ') %></p>
+  </section>
+<% end %>
 
 <% @teams.each do |team| %>
   <section class="team" id="team_<%= team.id %>">

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -8,6 +8,12 @@
   <%= submit_tag("Search", name: nil) %>
 <% end %>
 
+<section id="team_stats">
+  <h2>Statistics:</h2>
+  <p>Average Age: <%= @average_age %></p>
+  <p>All Team Locations: <%= @team_locations %></p>
+</section>
+
 <% @teams.each do |team| %>
   <section class="team" id="team_<%= team.id %>">
     <h2><%= team.name %></h2>

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe 'teams index page', type: :feature do
 
   it 'displays the statistics of the teams' do
     expect(page).to have_content("Statistics:")
-    expect(page).to have_content("Average Age: 6")
-    expect(page).to have_content("All Team Locations: Europe, Ukraine")
+    expect(page).to have_content("Average Age: #{(@team_1.age + @team_2.age) / 2}")
+    expect(page).to have_content("All Team Locations: #{@team_2.location}, #{@team_1.location}")
   end
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -108,4 +108,10 @@ RSpec.describe 'teams index page', type: :feature do
 
     expect(current_path).to eq("/teams/new")
   end
+
+  it 'displays the statistics of the teams' do
+    expect(page).to have_content("Statistics:")
+    expect(page).to have_content("Average Age: 6")
+    expect(page).to have_content("All Team Locations: Europe, Ukraine")
+  end
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -114,4 +114,22 @@ RSpec.describe 'teams index page', type: :feature do
     expect(page).to have_content("Average Age: #{(@team_1.age + @team_2.age) / 2}")
     expect(page).to have_content("All Team Locations: #{@team_2.location}, #{@team_1.location}")
   end
+
+  it 'displays filtered teams statistics correctly' do
+    visit '/teams?age=4'
+
+    expect(page).to have_content("Statistics:")
+    expect(page).to have_content("Average Age: #{@team_1.age}")
+    expect(page).to have_content("All Team Locations: #{@team_1.location}")
+  end
+
+  it 'displays nothing when filtered for no teams' do
+    visit '/teams?age=2'
+
+    expect(page).to_not have_content("Statistics:")
+    expect(page).to_not have_content("Average Age: #{(@team_1.age + @team_2.age) / 2}")
+    expect(page).to_not have_content("All Team Locations: #{@team_2.location}, #{@team_1.location}")
+
+    expect(page).to have_content("Sorry, nothing for you here!")
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Team, type: :model do
     it "should only return teams by age" do
       expect(Team.by_age(4)).to eq([@team_1])
     end
+
+    it 'should return all teams average age' do
+      expect(Team.average_age).to eq(6)
+    end
+
+    it 'should return all unique team locations' do
+      Team.create(name: "Not So Secret", age: 6, location: "Europe")
+
+      expect(Team.locations).to eq(["Europe", "Ukraine"])
+    end
   end
 
   describe "instance methods" do

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Team, type: :model do
     it 'should return all unique team locations' do
       Team.create(name: "Not So Secret", age: 6, location: "Europe")
 
-      expect(Team.locations).to eq(["Europe", "Ukraine"])
+      expect(Team.locations).to eq(["Ukraine", "Europe"])
     end
   end
 


### PR DESCRIPTION
This PR brings in the functionality of displaying a blurb with some Team statistics at the top of our /teams index page. All of the math and aggregation is done in ActiveRecord, removing any requirement for formatting or sorting done in our Teams Controller. The only changes are made to round our Average Age statistic to a reasonable amount in the View, and the list of Locations to be formatted as a comma separated list in the View.
We also allowed for the index page to display a helpful message when sorting by age. If the user queries an age that does not have any Teams, they will be presented with a message letting them know that. Otherwise, the new query list of Teams will display new Stats based on only those Teams.