### PR TITLE
Team Show page

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -20,6 +20,10 @@ class TeamsController < ApplicationController
     redirect_to "/teams"
   end
 
+  def show
+    @team = Team.find(params[:id])
+  end
+
   private
 
   def team_params

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -19,7 +19,7 @@
 
 <% @teams.each do |team| %>
   <section class="team" id="team_<%= team.id %>">
-    <h2><%= team.name %></h2>
+    <h2><a href="/teams/<%= team.id %>"><%= team.name %></a></h2>
     <img src="<%= team.image %>" alt="<%= team.name %> Logo">
     <p>Age: <%= team.age %></p>
     <p>Location: <%= team.location %></p>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -1,0 +1,14 @@
+<section class="@team" id="@team_<%= @team.id %>">
+  <h2><%= @team.name %></h2>
+  <img src="<%= @team.image %>" alt="<%= @team.name %> Logo">
+  <p>Age: <%= @team.age %></p>
+  <p>Location: <%= @team.location %></p>
+  <p>Player Count: <%= @team.player_count %></p>
+  <% @team.players.each do |player| %>
+  <aside class="player" id="player_<%= player.id %>">
+    <img src="<%= player.image %>" alt="<%= player.name %> Photo">
+    <p>Name: <%= player.name %></p>
+    <p>Winrate: <%= player.winrate %></p>
+  </aside>
+  <% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   get '/teams', to: 'teams#index'
   get 'teams/new', to: 'teams#new'
   post '/teams', to: 'teams#create'
+  get '/teams/:id', to: 'teams#show'
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -132,4 +132,10 @@ RSpec.describe 'teams index page', type: :feature do
 
     expect(page).to have_content("Sorry, nothing for you here!")
   end
+
+  it 'has a link to that teams show page' do
+    click_link "#{@team_1.name}"
+
+    expect(current_path).to eq("/teams/#{@team_1.id}")
+  end
 end

--- a/spec/features/teams/show_spec.rb
+++ b/spec/features/teams/show_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'As a user', type: :feature do
+  before :each do
+    @team_1 = Team.create(name: "Secret", age: 4, location: "Europe", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/1838315.png")
+    @team_2 = Team.create(name: "Natus Vincere", age: 8, location: "Ukraine", image: "https://steamcdn-a.akamaihd.net/apps/dota2/images/team_logos/36.png")
+
+    @puppey = @team_1.players.create(name: "Puppey", winrate: 0.666, image: "https://www.opendota.com/assets/images/dota2/players/87278757.png")
+    @chu = @team_2.players.create(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
+  end
+
+  describe 'When I visit a Team show page' do
+    it 'shows only that Teams information' do
+      visit "/teams/#{@team_1.id}"
+
+      expect(page).to have_content(@team_1.name)
+      expect(page).to have_content("Age: #{@team_1.age}")
+      expect(page).to have_content("Location: #{@team_1.location}")
+
+      expect(page).to_not have_content(@team_2.name)
+      expect(page).to_not have_content("Age: #{@team_2.age}")
+      expect(page).to_not have_content("Location: #{@team_2.location}")
+    end
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality that each Team has a link to their own profile page, displaying only their information. This can be accessed either through the URL, or more conveniently, through a link as a part of each Teams name. 
The display of the Team information is identical to the way each team is displayed on the index page.