### PR TITLE
Players Stats

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,10 +4,14 @@ class TeamsController < ApplicationController
       @teams = Team.by_age(params[:age])
       @average_age = @teams.average_age
       @team_locations = @teams.locations
+      @total_player_count = @teams.total_player_count
+      @average_player_winrate = @teams.average_player_winrate
     else
       @teams = Team.all
       @average_age = Team.average_age
       @team_locations = Team.locations
+      @total_player_count = Team.total_player_count
+      @average_player_winrate = Team.average_player_winrate
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -20,20 +20,18 @@ class Team < ApplicationRecord
   end
 
   def self.total_player_count
-    # total = 0
-    # all.each do |team|
-    #   total += team.player_count
-    # end
-    # total
-    Player.count
+    total = 0
+    all.each do |team|
+      total += team.player_count
+    end
+    total
   end
 
   def self.average_player_winrate
-    # total = 0
-    # all.each do |team|
-    #   total += team.players.sum(:winrate)
-    # end
-    # total_player_count > 0 ? total / total_player_count : 0
-    Player.average(:winrate)
+    total = 0
+    all.each do |team|
+      total += team.players.sum(:winrate)
+    end
+    total_player_count > 0 ? total / total_player_count : 0
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -18,4 +18,22 @@ class Team < ApplicationRecord
   def self.locations
     select(:location).distinct.pluck(:location)
   end
+
+  def self.total_player_count
+    # total = 0
+    # all.each do |team|
+    #   total += team.player_count
+    # end
+    # total
+    Player.count
+  end
+
+  def self.average_player_winrate
+    # total = 0
+    # all.each do |team|
+    #   total += team.players.sum(:winrate)
+    # end
+    # total_player_count > 0 ? total / total_player_count : 0
+    Player.average(:winrate)
+  end
 end

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -14,6 +14,8 @@
     <h2>Statistics:</h2>
     <p>Average Age: <%= @average_age.round(2) %></p>
     <p>All Team Locations: <%= @team_locations.join(', ') %></p>
+    <p>Total Players: <%= @total_player_count %></p>
+    <p>Average Player Winrate: <%= @average_player_winrate %></p>
   </section>
 <% end %>
 

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -146,4 +146,14 @@ RSpec.describe 'teams index page', type: :feature do
     expect(page).to have_content("Total Players: #{(@team_1.players.count + @team_2.players.count)}")
     expect(page).to have_content("Average Player Winrate: #{expected_average}")
   end
+
+  it 'displays player statistics for filtered teams' do
+    visit '/teams?age=4'
+
+    expected_average = @team_1.players.sum(:winrate) / @team_1.players.count
+
+    expect(page).to have_content("Statistics:")
+    expect(page).to have_content("Total Players: #{@team_1.players.count}")
+    expect(page).to have_content("Average Player Winrate: #{expected_average}")
+  end
 end

--- a/spec/features/teams/index_spec.rb
+++ b/spec/features/teams/index_spec.rb
@@ -138,4 +138,12 @@ RSpec.describe 'teams index page', type: :feature do
 
     expect(current_path).to eq("/teams/#{@team_1.id}")
   end
+
+  it 'displays player statistics for the teams' do
+    expected_average = ((@team_1.players.sum(:winrate) + @team_2.players.sum(:winrate)) / (@team_1.players.count + @team_2.players.count))
+    
+    expect(page).to have_content("Statistics:")
+    expect(page).to have_content("Total Players: #{(@team_1.players.count + @team_2.players.count)}")
+    expect(page).to have_content("Average Player Winrate: #{expected_average}")
+  end
 end

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Team, type: :model do
       @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
       @team_2.players.create!(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
 
-      expect (Team.total_player_count).to eq(3)
+      expect(Team.total_player_count).to eq(3)
     end
 
     it 'should return the average player winrate of all teams' do
@@ -44,7 +44,7 @@ RSpec.describe Team, type: :model do
       @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
       @team_2.players.create!(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
 
-      expect(Team.average_player_winrate).to eq(0.623)
+      expect(Team.average_player_winrate).to eq(0.622666666666667e0)
     end
   end
 

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Team, type: :model do
       @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
       @team_2.players.create!(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
 
-      expect(Team.average_player_winrate).to eq(0.622666666666667e0)
+      expect(Team.average_player_winrate).to eq(0.6226666666666666)
     end
   end
 

--- a/spec/models/teams_spec.rb
+++ b/spec/models/teams_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Team, type: :model do
 
       expect(Team.locations).to eq(["Ukraine", "Europe"])
     end
+
+    it 'should return all teams player counts' do
+      @team_1.players.create!(name: "Puppey", winrate: 0.666, image: "https://www.opendota.com/assets/images/dota2/players/87278757.png")
+      @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
+      @team_2.players.create!(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
+
+      expect (Team.total_player_count).to eq(3)
+    end
+
+    it 'should return the average player winrate of all teams' do
+      @team_1.players.create!(name: "Puppey", winrate: 0.666, image: "https://www.opendota.com/assets/images/dota2/players/87278757.png")
+      @team_1.players.create!(name: "MidOne", winrate: 0.681, image: "https://www.opendota.com/assets/images/dota2/players/116585378.png")
+      @team_2.players.create!(name: "Chu", winrate: 0.521, image: "https://steamcdn-a.akamaihd.net/steamcommunity/public/images/avatars/7c/7c590378e43123beebb838e2987eb6773febe1a6_full.jpg")
+
+      expect(Team.average_player_winrate).to eq(0.623)
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
This PR brings in the functionality of additional statistics displayed on the /teams index page. These new stats are Player related, for all the Teams that are currently displayed on the page.
The stats are for the Total Player Count for all teams displayed, and the other is for Average Player Winrate for all teams displayed.
This functionality will work for both all of our Teams as displayed on /teams, and also for when the Teams are filtered, like when done by age.